### PR TITLE
Include standard library header <deque>

### DIFF
--- a/src/httpserver.cpp
+++ b/src/httpserver.cpp
@@ -27,6 +27,7 @@
 #include <event2/buffer.h>
 #include <event2/util.h>
 #include <event2/keyvalq_struct.h>
+#include <deque>
 
 #ifdef EVENT__HAVE_NETINET_IN_H
 #include <netinet/in.h>


### PR DESCRIPTION
Include standard library header <deque> to build with clang 13.0.1 .